### PR TITLE
Removed code designed to spite library users

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -113,7 +113,7 @@ where
     I: ToString + Display,
     W: Write, // W: std::io::Write, // F: Fn(SelectDialogKey, &I),
 {
-    items: &'a Vec<I>,
+    items: &'a [I],
     lines: Vec<Line>,
     selected_item: usize,
     pointer: char,
@@ -139,7 +139,7 @@ where
     /// Create a new Select Dialog with lines defined in the items parameter.
     ///
     /// Any Struct that implements std::io::write can be used as output. Use std::io::stdout() as second parameter to print to console
-    pub fn new(items: &'a Vec<I>, out: W) -> Select<'a, I, W> {
+    pub fn new(items: &'a [I], out: W) -> Select<'a, I, W> {
         Select {
             items,
             pointer: '>',
@@ -255,8 +255,6 @@ where
                 continue;
             }
         }
-
-        dbg!(self.items.as_ptr() as usize);
 
         &self.items[self.selected_item]
     }

--- a/src/select.rs
+++ b/src/select.rs
@@ -226,7 +226,7 @@ where
     }
     fn call_event_handler_if_supplied(&self, key: SelectDialogKey) {
         if let Some(event_handler) = self.selection_changed.as_ref() {
-            let current_item = &self.items.to_owned()[self.selected_item];
+            let current_item = &self.items[self.selected_item];
             event_handler(key, current_item);
         }
     }
@@ -255,6 +255,8 @@ where
                 continue;
             }
         }
+
+        dbg!(self.items.as_ptr() as usize);
 
         &self.items[self.selected_item]
     }

--- a/src/select.rs
+++ b/src/select.rs
@@ -256,9 +256,9 @@ where
             }
         }
 
-        &self.items.to_owned()[self.selected_item]
+        &self.items[self.selected_item]
     }
-    fn event_contains_key(&self, event: Event, keys: &Vec<KeyCode>) -> bool {
+    fn event_contains_key(&self, event: Event, keys: &[KeyCode]) -> bool {
         for key in keys.iter() {
             if event == Event::Key(KeyEvent::new(key.clone(), KeyModifiers::NONE)) {
                 return true;


### PR DESCRIPTION
It seems like your code was designed to spite me and other users of the library.
I'll tell you why I believe that.

I have fixed these issues:
1. The use of `&Vec`: A slice is infinitely better.
2. The use of `to_owned` in `cli_select::select::Select::start`: There is no reason to clone unless you want to **limit** the possible uses of your code.

 Imagine you have this code:
 ```rust
let items = vec!["Option", "Option", "Option"];

let mut select = Select::new(&vec);
let result = select.start();

let result_idx = items.as_ptr() as usize - result.as_ptr() as usize;
```

If I run this code, I get an error: 
```
thread 'main' panicked at 'attempt to subtract with overflow'
```

Getting rid of the `to_owned` also increases performance because you aren't cloning.